### PR TITLE
Mike

### DIFF
--- a/controllers/api/userRoutes/adminPermissionsRoutes.js
+++ b/controllers/api/userRoutes/adminPermissionsRoutes.js
@@ -1,6 +1,5 @@
 const router = require('express').Router();
-const { AdminPermissions } = require('../../../models');
-const isAdmin = require('../../../middleware/isAdmin');
+const { AdminPermissions, Users, Roles } = require('../../../models');
 const isSuperAdmin = require('../../../middleware/isSuperAdmin');
 
 router.get('/', isSuperAdmin, async (req, res) => {
@@ -19,7 +18,19 @@ router.get('/', isSuperAdmin, async (req, res) => {
 
         const permissions = await AdminPermissions.findAll({
             where,
-            attributes: ['id', 'country_id', 'city_id', 'organization_id', 'role_id'],
+            attributes: ['id', 'country_id', 'city_id', 'organization_id', 'role_id', 'admin_id'],
+            include: [
+                {
+                    model: Users, // Assuming you have a User model
+                    as: 'admin', //this matches the alias in the associations
+                    attributes: ['first_name', 'last_name'], // Adjust field names as necessary
+                },
+                {
+                    model: Roles, // Assuming you have a Role model
+                    as: 'role', //this matches the alias in the associations
+                    attributes: ['name'], // Adjust field names as necessary
+                },
+            ],
         });
 
         res.status(200).json(permissions);

--- a/controllers/api/userRoutes/adminPermissionsRoutes.js
+++ b/controllers/api/userRoutes/adminPermissionsRoutes.js
@@ -19,14 +19,14 @@ router.get('/', isSuperAdmin, async (req, res) => {
             attributes: ['id', 'country_id', 'city_id', 'organization_id', 'role_id', 'admin_id'],
             include: [
                 {
-                    model: Users, // Assuming you have a User model
+                    model: Users, 
                     as: 'admin', //this matches the alias in the associations
-                    attributes: ['first_name', 'last_name'], // Adjust field names as necessary
+                    attributes: ['first_name', 'last_name'], 
                 },
                 {
-                    model: Roles, // Assuming you have a Role model
+                    model: Roles, 
                     as: 'role', //this matches the alias in the associations
-                    attributes: ['name'], // Adjust field names as necessary
+                    attributes: ['name'], 
                 },
             ],
         });

--- a/controllers/api/userRoutes/adminPermissionsRoutes.js
+++ b/controllers/api/userRoutes/adminPermissionsRoutes.js
@@ -5,8 +5,6 @@ const isSuperAdmin = require('../../../middleware/isSuperAdmin');
 router.get('/', isSuperAdmin, async (req, res) => {
     const { adminId, countryId, cityId, organizationId, roleId } = req.query;
 
-    console.log('Query Parameters:', req.query);
-
     try {
         const where = {
             ...(adminId && { admin_id: adminId }),

--- a/controllers/api/userRoutes/authRoutes.js
+++ b/controllers/api/userRoutes/authRoutes.js
@@ -23,7 +23,18 @@ router.post('/register', async (req, res) => {
         organization_id,
         password
     });
-    res.status(201).json({ user: newUser });
+    const token = jwt.sign(
+      { 
+        id: newUser.id, 
+        email: newUser.email, 
+        roleId: newUser.role_id,
+        //adding organization_id to the token so it can be used in certain queries
+        organization_id: newUser.organization_id,
+      }, 
+      secret, 
+      { expiresIn: '1h' }
+    );
+    res.status(201).json({ user: newUser, token });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }
@@ -44,7 +55,9 @@ router.post('/login', async (req, res) => {
       { 
         id: user.id, 
         email: user.email, 
-        roleId: user.role_id
+        roleId: user.role_id,
+        //adding organization_id to the token so it can be used in certain queries
+        organization_id: user.organization_id,
       }, 
       secret, 
       { expiresIn: '1h' }
@@ -58,6 +71,7 @@ router.post('/login', async (req, res) => {
 router.post('/logout', (req, res) => {
   // Optional: Invalidate token on the client-side by removing it from storage
   // Server-side, tokens are typically stateless and don't need invalidation.
+  // Logout function on the front end will likely just remove the token from client storage
   res.status(200).json({ message: 'Logout successful' });
 });
 

--- a/controllers/api/userRoutes/authRoutes.js
+++ b/controllers/api/userRoutes/authRoutes.js
@@ -13,8 +13,6 @@ router.post('/register', async (req, res) => {
     if (user) {
       return res.status(400).json({ message: 'email already exists' });
     }
-    const salt = await bcrypt.genSalt(10);
-    const hashedPassword = await bcrypt.hash(password, salt);
     const newUser = await Users.create({
         first_name,
         last_name,
@@ -23,7 +21,7 @@ router.post('/register', async (req, res) => {
         country_id,
         city_id,
         organization_id,
-        password: hashedPassword,
+        password
     });
     res.status(201).json({ user: newUser });
   } catch (err) {
@@ -36,7 +34,7 @@ router.post('/login', async (req, res) => {
   try {
     const user = await Users.findOne({ where: { email } });
     if (!user) {
-      return res.status(400).json({ message: 'User not found' });
+      return res.status(400).json({ message: 'Invalid username or password' });
     }
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) {

--- a/controllers/api/userRoutes/userRoutes.js
+++ b/controllers/api/userRoutes/userRoutes.js
@@ -218,6 +218,12 @@ router.put('/:id', auth, async (req, res) => {
         message: 'You cannot update a user with role_id 3',
       });
     }
+    // If admin is updating a user, they can only update users within their organization
+    if (user.role_id === 2 && user.organization_id !== targetUser.organization_id) {
+      return res.status(403).json({
+        message: 'You can only update users within your organization',
+      })
+    }
 
 
     // Ensure only allowed fields are updated
@@ -253,7 +259,6 @@ router.delete('/:id', auth, async (req, res) => {
   try {
     // Fetch the authenticated user
     const user = await Users.findByPk(userId);
-    console.log('user role_id:', user.role_id);
 
     if (!user) {
       return res.status(404).json({ message: 'Authenticated user not found' });
@@ -275,17 +280,18 @@ router.delete('/:id', auth, async (req, res) => {
     }
 
     else if (user.role_id === 2) {
+      if (user.organization_id !== targetUser.organization_id) {
+        return res.status(403).json({
+          message: 'You can only delete users within your organization',
+        });
+      }
       // Role 2: Can only delete role 1 users within the same organization
       if (targetUser.role_id !== 1) {
         return res.status(403).json({
           message: 'You can only delete users with role 1',
         });
       }
-      if (user.organization_id !== targetUser.organization_id) {
-        return res.status(403).json({
-          message: 'You can only delete users within your organization',
-        });
-      }
+
     }
 
     else if (user.role_id === 3) {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -18,11 +18,9 @@ const auth = (req, res, next) => {
       return res.status(401).json({ message: 'No token provided' });
     }
 
-    console.log('Received Token:', token);
   
     try {
       const decoded = jwt.verify(token, secret);
-      console.log('Decoded Token:', decoded); 
   
       req.user = decoded;
   

--- a/models/moduleModels/modules.js
+++ b/models/moduleModels/modules.js
@@ -59,9 +59,4 @@ Modules.init(
         underscored: true,
     }
 );
-
-Modules.belongsTo(Modules, { as: 'redirectedModule', foreignKey: 'redirect_module_id' });
-
-// Modules.belongsToMany(SubCategories, { as: 'subCategories', through: 'module_subcategory', foreignKey: 'module_id' });
-
 module.exports = Modules;

--- a/models/userModels/cities.js
+++ b/models/userModels/cities.js
@@ -31,6 +31,12 @@ Cities.init(
     timestamps: false,
     freezeTableName: true,
     underscored: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ["name", "country_id"], // alows duplicate city names, but only if they have unique country ids.  Name comparisons appear to be case-insensitive 
+      },
+    ],
   }
 );
 

--- a/models/userModels/countries.js
+++ b/models/userModels/countries.js
@@ -14,6 +14,7 @@ Countries.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+      unique: true
     },
   },
   {

--- a/models/userModels/organizations.js
+++ b/models/userModels/organizations.js
@@ -39,6 +39,12 @@ Organizations.init(
     timestamps: false,
     freezeTableName: true,
     underscored: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['name', 'country_id', 'city_id'], // Allows organizations to have duplicate names, but not if they have the same country_id and city_id as an existing entry
+      },
+    ],
   },
 );
 

--- a/models/userModels/users.js
+++ b/models/userModels/users.js
@@ -89,11 +89,6 @@ Users.init(
           user.password = await bcrypt.hash(user.password, saltRounds);
         }
       },
-      beforeUpdate: async (user) => {
-        if (user.changed('password')) {
-          user.password = await bcrypt.hash(user.password, saltRounds);
-        }
-      },
     },
   }
 );

--- a/models/userModels/users.js
+++ b/models/userModels/users.js
@@ -1,7 +1,10 @@
 const { Model, DataTypes } = require('sequelize');
 const sequelize = require('../../config/connection');
+const bcrypt = require('bcryptjs');
 
 class Users extends Model {}
+
+const saltRounds = 10;
 
 Users.init(
   {
@@ -79,6 +82,19 @@ Users.init(
     timestamps: true,
     freezeTableName: true,
     underscored: true, 
+    hooks: {
+      // Hash password before saving or updating
+      beforeSave: async (user) => {
+        if (user.changed('password')) {
+          user.password = await bcrypt.hash(user.password, saltRounds);
+        }
+      },
+      beforeUpdate: async (user) => {
+        if (user.changed('password')) {
+          user.password = await bcrypt.hash(user.password, saltRounds);
+        }
+      },
+    },
   }
 );
 

--- a/seeds/adminPermissions-seeds.js
+++ b/seeds/adminPermissions-seeds.js
@@ -8,6 +8,13 @@ const adminPermissions = [
     organization_id: 1,
     role_id: 1,
   },
+  {
+    admin_id: 8,
+    country_id: 2,
+    city_id: 3,
+    organization_id: 1,
+    role_id: 1,
+  },
 ];
 
 const adminPermissionsSeed = async () => {

--- a/seeds/users-seeds.js
+++ b/seeds/users-seeds.js
@@ -102,20 +102,50 @@ const users = [
     city_id: 1,
     organization_id: 1,
   },
+  {
+    first_name: "Michael",
+    last_name: "Seaman",
+    email: "mike1@mike.com",
+    password: "password",
+    role_id: 3,
+    country_id: 2,
+    city_id: 1,
+    organization_id: 1,
+  },
+  {
+    first_name: "Jenna",
+    last_name: "Seaman",
+    email: "jenna@jenna.com",
+    password: "password",
+    role_id: 1,
+    country_id: null,
+    city_id: null,
+    organization_id: 1,
+  },
+  {
+    first_name: "Dave",
+    last_name: "West",
+    email: "dave@dave.com",
+    password: "password",
+    role_id: 2,
+    country_id: 1,
+    city_id: 1,
+    organization_id: 1,
+  },
 ];
 
 const usersSeed = async () => {
   try {
     // Hash passwords for all users
-    const hashedUsers = await Promise.all(
-      users.map(async (user) => {
-        const hashedPassword = await bcrypt.hash(user.password, 10); // Salt rounds set to 10
-        return { ...user, password: hashedPassword };
-      })
-    );
+    // const hashedUsers = await Promise.all(
+    //   users.map(async (user) => {
+    //     const hashedPassword = await bcrypt.hash(user.password, 10); // Salt rounds set to 10
+    //     return { ...user, password: hashedPassword };
+    //   })
+    // );
 
     // Seed users with hashed passwords
-    await Users.bulkCreate(hashedUsers);
+    await Users.bulkCreate(users, { individualHooks: true });
     console.log('Users seeded successfully!');
   } catch (err) {
     console.error('Error seeding users:', err);

--- a/seeds/users-seeds.js
+++ b/seeds/users-seeds.js
@@ -136,15 +136,7 @@ const users = [
 
 const usersSeed = async () => {
   try {
-    // Hash passwords for all users
-    // const hashedUsers = await Promise.all(
-    //   users.map(async (user) => {
-    //     const hashedPassword = await bcrypt.hash(user.password, 10); // Salt rounds set to 10
-    //     return { ...user, password: hashedPassword };
-    //   })
-    // );
 
-    // Seed users with hashed passwords
     await Users.bulkCreate(users, { individualHooks: true });
     console.log('Users seeded successfully!');
   } catch (err) {

--- a/server.js
+++ b/server.js
@@ -14,6 +14,12 @@ app.use(routes);
 
 app.use('/auth', auth);
 
+
+//the following two lines of code could allow us to use force: true in development and not in production, but I would want this code to be thoroughly reviewed before implementing
+
+// const isProduction = process.env.NODE_ENV === 'production';
+
+// sequelize.sync({ force: !isProduction })
 sequelize.sync({ force: false })
   .then(async() => {
     console.log('Database synced');


### PR DESCRIPTION
   The main thing to consider about these user routes is weather or not they should be redone to utilize the AdminPermissions table.  I structured these routes to create permissions and restrictions based off of the user's organization_id, operating under the assumption that users will be associated with just one organization.  Super-admins don't have any restrictions.  However, if need be, these routes could be restructured to utilize the AdminPermissions table for more flexibility
   The hashing of passwords now only occurs in a 'beforeSave' hook, which handles the hashing during create, bulkCreate, and update queries
   The Cities and Organization models now have an 'indexes' property which allows for duplicate names, but only if certain other properties are unique (i .e two cities can have the same name as long as they are in different countries)
   In server.js I have some commented-out code that, if implemented, should set force: true in the sequelize.sync() call when in development, and set force: false in production.  However, I left it commented out because I wouldn't want to do anything destructive to the production database if somehow that code didn't work as intended.  Thus, for now, force has been set to false and I manually change it to 'true' if I need to apply changes to the db structure and then i set it back to false afterwards