### PR TITLE
Mike

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+
 
 module.exports = {
   "development": {

--- a/controllers/api/userRoutes/adminPermissionsRoutes.js
+++ b/controllers/api/userRoutes/adminPermissionsRoutes.js
@@ -1,6 +1,5 @@
 const router = require('express').Router();
-const { AdminPermissions } = require('../../../models');
-const isAdmin = require('../../../middleware/isAdmin');
+const { AdminPermissions, Users, Roles } = require('../../../models');
 const isSuperAdmin = require('../../../middleware/isSuperAdmin');
 
 router.get('/', isSuperAdmin, async (req, res) => {
@@ -19,7 +18,19 @@ router.get('/', isSuperAdmin, async (req, res) => {
 
         const permissions = await AdminPermissions.findAll({
             where,
-            attributes: ['id', 'country_id', 'city_id', 'organization_id', 'role_id'],
+            attributes: ['id', 'country_id', 'city_id', 'organization_id', 'role_id', 'admin_id'],
+            include: [
+                {
+                    model: Users, // Assuming you have a User model
+                    as: 'admin', //this matches the alias in the associations
+                    attributes: ['first_name', 'last_name'], // Adjust field names as necessary
+                },
+                {
+                    model: Roles, // Assuming you have a Role model
+                    as: 'role', //this matches the alias in the associations
+                    attributes: ['name'], // Adjust field names as necessary
+                },
+            ],
         });
 
         res.status(200).json(permissions);

--- a/controllers/api/userRoutes/adminPermissionsRoutes.js
+++ b/controllers/api/userRoutes/adminPermissionsRoutes.js
@@ -19,14 +19,14 @@ router.get('/', isSuperAdmin, async (req, res) => {
             attributes: ['id', 'country_id', 'city_id', 'organization_id', 'role_id', 'admin_id'],
             include: [
                 {
-                    model: Users, // Assuming you have a User model
+                    model: Users, 
                     as: 'admin', //this matches the alias in the associations
-                    attributes: ['first_name', 'last_name'], // Adjust field names as necessary
+                    attributes: ['first_name', 'last_name'], 
                 },
                 {
-                    model: Roles, // Assuming you have a Role model
+                    model: Roles, 
                     as: 'role', //this matches the alias in the associations
-                    attributes: ['name'], // Adjust field names as necessary
+                    attributes: ['name'], 
                 },
             ],
         });

--- a/controllers/api/userRoutes/adminPermissionsRoutes.js
+++ b/controllers/api/userRoutes/adminPermissionsRoutes.js
@@ -5,8 +5,6 @@ const isSuperAdmin = require('../../../middleware/isSuperAdmin');
 router.get('/', isSuperAdmin, async (req, res) => {
     const { adminId, countryId, cityId, organizationId, roleId } = req.query;
 
-    console.log('Query Parameters:', req.query);
-
     try {
         const where = {
             ...(adminId && { admin_id: adminId }),

--- a/controllers/api/userRoutes/authRoutes.js
+++ b/controllers/api/userRoutes/authRoutes.js
@@ -23,7 +23,18 @@ router.post('/register', async (req, res) => {
         organization_id,
         password
     });
-    res.status(201).json({ user: newUser });
+    const token = jwt.sign(
+      { 
+        id: newUser.id, 
+        email: newUser.email, 
+        roleId: newUser.role_id,
+        //adding organization_id to the token so it can be used in certain queries
+        organization_id: newUser.organization_id,
+      }, 
+      secret, 
+      { expiresIn: '1h' }
+    );
+    res.status(201).json({ user: newUser, token });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }
@@ -44,7 +55,9 @@ router.post('/login', async (req, res) => {
       { 
         id: user.id, 
         email: user.email, 
-        roleId: user.role_id
+        roleId: user.role_id,
+        //adding organization_id to the token so it can be used in certain queries
+        organization_id: user.organization_id,
       }, 
       secret, 
       { expiresIn: '1h' }
@@ -58,6 +71,7 @@ router.post('/login', async (req, res) => {
 router.post('/logout', (req, res) => {
   // Optional: Invalidate token on the client-side by removing it from storage
   // Server-side, tokens are typically stateless and don't need invalidation.
+  // Logout function on the front end will likely just remove the token from client storage
   res.status(200).json({ message: 'Logout successful' });
 });
 

--- a/controllers/api/userRoutes/authRoutes.js
+++ b/controllers/api/userRoutes/authRoutes.js
@@ -2,7 +2,6 @@ const router = require('express').Router();
 const { Users, Countries } = require('../../../models');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
-require('dotenv').config();
 
 const secret = process.env.SECRET;
 
@@ -30,6 +29,7 @@ router.post('/register', async (req, res) => {
         country_id,
         city_id,
         organization_id,
+        //password is hashed before being stored in the database, using a hook in the User model
         password
     });
     const token = jwt.sign(
@@ -59,10 +59,6 @@ router.post('/login', async (req, res) => {
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) {
       return res.status(400).json({ message: 'Invalid username or password' });
-    }
-    //if the request is coming from the admin dashboard, check if the user is a super admin and deny access if not
-    if (context === 'admin' && user.role_id !== 3) {
-      return res.status(403).json({ message: 'Access denied: super admin required' });
     }
 
     const token = jwt.sign(

--- a/controllers/api/userRoutes/authRoutes.js
+++ b/controllers/api/userRoutes/authRoutes.js
@@ -50,7 +50,7 @@ router.post('/register', async (req, res) => {
 });
 
 router.post('/login', async (req, res) => {
-    const { email, password } = req.body;
+  const { email, password, context } = req.body; // Add "context" to the request body to detect if the request is coming from the general app or the admin dashboard
   try {
     const user = await Users.findOne({ where: { email } });
     if (!user) {
@@ -60,6 +60,11 @@ router.post('/login', async (req, res) => {
     if (!valid) {
       return res.status(400).json({ message: 'Invalid username or password' });
     }
+    //if the request is coming from the admin dashboard, check if the user is a super admin and deny access if not
+    if (context === 'admin' && user.role_id !== 3) {
+      return res.status(403).json({ message: 'Access denied: super admin required' });
+    }
+
     const token = jwt.sign(
       { 
         id: user.id, 

--- a/controllers/api/userRoutes/authRoutes.js
+++ b/controllers/api/userRoutes/authRoutes.js
@@ -13,8 +13,6 @@ router.post('/register', async (req, res) => {
     if (user) {
       return res.status(400).json({ message: 'email already exists' });
     }
-    const salt = await bcrypt.genSalt(10);
-    const hashedPassword = await bcrypt.hash(password, salt);
     const newUser = await Users.create({
         first_name,
         last_name,
@@ -23,7 +21,7 @@ router.post('/register', async (req, res) => {
         country_id,
         city_id,
         organization_id,
-        password: hashedPassword,
+        password
     });
     res.status(201).json({ user: newUser });
   } catch (err) {
@@ -36,7 +34,7 @@ router.post('/login', async (req, res) => {
   try {
     const user = await Users.findOne({ where: { email } });
     if (!user) {
-      return res.status(400).json({ message: 'User not found' });
+      return res.status(400).json({ message: 'Invalid username or password' });
     }
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) {

--- a/controllers/api/userRoutes/userRoutes.js
+++ b/controllers/api/userRoutes/userRoutes.js
@@ -218,6 +218,12 @@ router.put('/:id', auth, async (req, res) => {
         message: 'You cannot update a user with role_id 3',
       });
     }
+    // If admin is updating a user, they can only update users within their organization
+    if (user.role_id === 2 && user.organization_id !== targetUser.organization_id) {
+      return res.status(403).json({
+        message: 'You can only update users within your organization',
+      })
+    }
 
 
     // Ensure only allowed fields are updated
@@ -253,7 +259,6 @@ router.delete('/:id', auth, async (req, res) => {
   try {
     // Fetch the authenticated user
     const user = await Users.findByPk(userId);
-    console.log('user role_id:', user.role_id);
 
     if (!user) {
       return res.status(404).json({ message: 'Authenticated user not found' });
@@ -275,17 +280,18 @@ router.delete('/:id', auth, async (req, res) => {
     }
 
     else if (user.role_id === 2) {
+      if (user.organization_id !== targetUser.organization_id) {
+        return res.status(403).json({
+          message: 'You can only delete users within your organization',
+        });
+      }
       // Role 2: Can only delete role 1 users within the same organization
       if (targetUser.role_id !== 1) {
         return res.status(403).json({
           message: 'You can only delete users with role 1',
         });
       }
-      if (user.organization_id !== targetUser.organization_id) {
-        return res.status(403).json({
-          message: 'You can only delete users within your organization',
-        });
-      }
+
     }
 
     else if (user.role_id === 3) {

--- a/controllers/api/userRoutes/userRoutes.js
+++ b/controllers/api/userRoutes/userRoutes.js
@@ -92,6 +92,7 @@ router.get('/me', auth, async (req, res) => {
 
     res.status(200).json(user);
   } catch (err) {
+    console.log(err);
     res.status(500).json({ message: err.message });
   }
 });

--- a/controllers/api/userRoutes/userRoutes.js
+++ b/controllers/api/userRoutes/userRoutes.js
@@ -1,21 +1,23 @@
-const router = require('express').Router();
-const { Users, Roles } = require('../../../models');
-const auth = require('../../../middleware/auth');
-const isAdmin = require('../../../middleware/isAdmin');
-const { Op, fn, col } = require('sequelize');
+const router = require("express").Router();
+const { Users, Roles } = require("../../../models");
+const auth = require("../../../middleware/auth");
+const isAdmin = require("../../../middleware/isAdmin");
+const { Op, fn, col, where } = require("sequelize");
 
-const validRoles = [1,2,3]
+const validRoles = [1, 2, 3];
 
-router.get('/', auth, isAdmin, async (req, res) => {
+router.get("/", auth, isAdmin, async (req, res) => {
   const { countryId, cityId, organizationId, roleId } = req.query;
+
+  const userIsAdmin = req.user.roleId === 2;
+  const userIsSuperAdmin = req.user.roleId === 3;
 
   try {
     // Initialize the base `where` clause
     let where = {};
 
     // Restrict data visibility based on user role
-    if (req.user.roleId === 2) {
-      
+    if (userIsAdmin) {
       // Role 2: Can only view users within the same organization
       where.organization_id = req.user.organization_id;
 
@@ -26,7 +28,7 @@ router.get('/', auth, isAdmin, async (req, res) => {
         ...(cityId && { city_id: cityId }),
         ...(roleId && { role_id: roleId }),
       };
-    } else if (req.user.roleId === 3) {
+    } else if (userIsSuperAdmin) {
       // Role 3: Can view any user
       where = {
         ...(countryId && { country_id: countryId }),
@@ -36,222 +38,331 @@ router.get('/', auth, isAdmin, async (req, res) => {
       };
     } else {
       // Role not recognized, deny access (should not happen due to `isAdmin`)
-      return res.status(403).json({ message: 'You do not have permission to view users' });
+      return res
+        .status(403)
+        .json({ message: "You do not have permission to view users" });
     }
 
     // Fetch the users with filters
     const users = await Users.findAll({
       where,
-      attributes: ['id', 'first_name', 'last_name', 'email'],
+      attributes: ["id", "first_name", "last_name", "email"],
       include: [
         {
           model: Roles,
-          as: 'role',
-          attributes: ['name'],
+          as: "role",
+          attributes: ["name"],
         },
       ],
     });
 
     res.status(200).json(users);
   } catch (err) {
+    console.log(err);
     res.status(500).json({ message: err.message });
   }
 });
 
-router.get('/search', auth, isAdmin, async (req, res) => {
+router.get("/search", auth, isAdmin, async (req, res) => {
   //users can be searched by one or more of the following fields. searches are case-insensitive
   const { email, first_name, last_name } = req.query;
+
+  const userIsAdmin = req.user.roleId === 2;
+  const userIsSuperAdmin = req.user.roleId === 3;
 
   try {
     // Initialize the base `where` clause
     let whereClause = {};
     // Restrict data visibility based on user role
 
-    if (req.user.roleId === 2) {
+    if (userIsAdmin) {
       // Role 2: Can only view users within the same organization
       whereClause.organization_id = req.user.organization_id;
-    } else if (req.user.roleId !== 3) {
-      // Role not recognized, deny access (should not happen due to `isAdmin` middleware)
-      return res.status(403).json({ message: 'You do not have permission to search for users' });
+      //if user is neither admin nor super admin, deny access
+    } else if (!userIsSuperAdmin) {
+      return res
+        .status(403)
+        .json({ message: "You do not have permission to search for users" });
     }
 
     // Add case-insensitive search filters if provided
     if (email) {
-      whereClause.email = {
-        [Op.like]: `%${email.toLowerCase()}%`,  // Ensure email in the db is compared case-insensitively
-      };
+      whereClause.email = { [Op.like]: '%' + email + '%' }
     }
+
     if (first_name) {
-      whereClause.first_name = {
-        [Op.like]: `%${first_name.toLowerCase()}%`,
-      };
+      whereClause.first_name = { [Op.like]: '%' + first_name + '%' }
     }
+
     if (last_name) {
-      whereClause.last_name = {
-        [Op.like]: `%${last_name.toLowerCase()}%`,
-      };
+      whereClause.last_name = { [Op.like]: '%' + last_name + '%' }
     }
 
     // Fetch the users with filters
     const users = await Users.findAll({
-      where: whereClause,  // Use the correct `where` object
-      attributes: ['id', 'first_name', 'last_name', 'email'],
+      where: whereClause, // Use the correct `where` object
+      attributes: ["id", "first_name", "last_name", "email"],
       include: [
         {
           model: Roles,
-          as: 'role',
-          attributes: ['name'],
+          as: "role",
+          attributes: ["name"],
         },
       ],
     });
 
     res.status(200).json(users);
   } catch (err) {
+    console.log(err);
     res.status(500).json({ message: err.message });
   }
 });
 
-
-router.get('/:id', auth, isAdmin, async (req, res) => {
+router.get("/:id", auth, isAdmin, async (req, res) => {
   const userId = req.params.id;
+  const userIsAdmin = req.user.roleId === 2;
+  const userIsSuperAdmin = req.user.roleId === 3;
 
   try {
     // Find the user by ID
     const user = await Users.findOne({
       where: { id: userId },
-      attributes: ['id', 'first_name', 'last_name', 'email', 'organization_id', 'role_id'],
-      include: [{ model: Roles, as: 'role', attributes: ['name'] }],
+      attributes: [
+        "id",
+        "first_name",
+        "last_name",
+        "email",
+        "organization_id",
+        "role_id",
+      ],
+      include: [{ model: Roles, as: "role", attributes: ["name"] }],
     });
 
     //
 
     // Check if user exists
     if (!user) {
-      return res.status(404).json({ message: 'User not found' });
+      return res.status(404).json({ message: "User not found" });
     }
 
     // Role-based access control (role 1 basically cant query any user)
-    if (req.user.roleId === 2) {
-      // Role 2 can only view users within the same organization
+    if (userIsAdmin) {
+      // admins can only view users within the same organization
       if (user.organization_id !== req.user.organization_id) {
-        return res.status(403).json({ message: 'Access denied, you can only access users from within your organization' });
+        return res
+          .status(403)
+          .json({
+            message:
+              "Access denied, you can only access users from within your organization",
+          });
       }
-    } else if (req.user.roleId !== 3) {
-      // Role 3 can view any user; other roles cannot
-      return res.status(403).json({ message: 'Access denied, invalid role id' });
+    } else if (!userIsSuperAdmin) {
+      // super admins can view any user; other roles cannot
+      return res
+        .status(403)
+        .json({ message: "Access denied, contact your system administrator" });
     }
 
     // Return the user details
     res.status(200).json(user);
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: 'An error occurred while fetching the user' });
+    console.log(err);
+    res
+      .status(500)
+      .json({ message: "An error occurred while fetching the user" });
   }
 });
 
-
-
-router.put('/:id', auth, async (req, res) => {
+// this route is for updating the user's OWN information
+router.put("/", auth, async (req, res) => {
   const userId = req.user.id; // Authenticated user's ID
-  const { id: unparsedTargetUserId } = req.params; // Target user ID
   const updatedData = req.body; // Data to update
-
-  //parse the targetUserId to an integer
-  const targetUserId = parseInt(unparsedTargetUserId);
 
   try {
     // Fetch the authenticated user
     const user = await Users.findByPk(userId);
 
     if (!user) {
-      return res.status(404).json({ message: 'Authenticated user not found' });
+      return res.status(404).json({ message: "Authenticated user not found" });
     }
-
-    // Fetch the target user
-    const targetUser = await Users.findByPk(targetUserId);
-
-    if (!targetUser) {
-      return res.status(404).json({ message: 'Target user not found' });
-    }
-
-    // Restrict modifications based on user roles
-    if (updatedData.role_id !== undefined) {
-      if(!validRoles.includes(user.role_id)){
-        return res.status(403).json({
-          message: 'Authenticated user role id not recognized',
-        });
-      }
-      if(!validRoles.includes(updatedData.role_id)){
-        return res.status(400).json({ message: 'Invalid role_id provided for user being updated' });
-      }
-      if (user.role_id === 1 || user.role_id === 2) {
-        // Role 1: Cannot modify any role_id
-        return res.status(403).json({
-          message: 'You do not have permission to modify role_id, contact a system admin',
-        });
-      } 
-    }
-
-    // Additional restriction for role_id 1: Only allow them to update themselves
-    if ((user.role_id === 1 || user.role_id === 2) && userId !== targetUserId) {
-      return res.status(403).json({
-        message: 'You are only permitted to update your own user details',
-      });
-    }
-
 
     // Ensure only allowed fields are updated
-    const allowedUpdates = ['first_name', 'last_name', 'email', 'password', user.role_id === 3 ? 'role_id' : null, 'country_id', 'city_id', 'organization_id'];
+    // user should not be allowed to update their role_id, organization_id, city_id, or country_id
+    const allowedUpdates = [
+      "first_name",
+      "last_name",
+      "email",
+      "password",
+    ];
     const filteredUpdates = Object.keys(updatedData)
       .filter((key) => allowedUpdates.includes(key))
       .reduce((obj, key) => {
         obj[key] = updatedData[key];
         return obj;
       }, {});
-
+    // if no valid updates are provided
+    if (Object.keys(filteredUpdates).length === 0) {
+      return res.status(400).json({ message: "No valid updates provided" });
+    }
     // Perform the update
-    await targetUser.update(filteredUpdates);
+    await user.update(filteredUpdates);
 
     // Fetch the updated user with excluded sensitive fields
-    const updatedUser = await Users.findByPk(targetUserId, {
-      attributes: { exclude: ['password'] }, // Exclude sensitive fields
+    const updatedUser = await Users.findByPk(userId, {
+      attributes: { exclude: ["password"] }, // Exclude sensitive fields
     });
 
     res.status(200).json({
-      message: 'User updated successfully',
+      message: "User updated successfully",
       user: updatedUser,
     });
   } catch (err) {
+    console.log(err);
     res.status(500).json({ message: err.message });
   }
-});
+})
 
-router.delete('/:id', auth, async (req, res) => {
-  const userId = req.user.id; // Authenticated user's ID
-  const { id: targetUserId } = req.params; // Target user ID to delete
+// this route is for updating OTHER users only.
+router.put("/:id", auth, isAdmin, async (req, res) => {
+  const userRoleId = req.user.roleId; // Authenticated user's role ID
+  const { id: unparsedTargetUserId } = req.params; // Target user ID
+  //parse the targetUserId to an integer
+  const targetUserId = parseInt(unparsedTargetUserId);
+  const updatedData = req.body; // Data to update
+
+  //normal users have been blocked by the isAdmin middleware
+  const userIsAdmin = userRoleId === 2;
+  const userIsSuperAdmin = userRoleId === 3;
 
   try {
-    // Fetch the authenticated user
-    const user = await Users.findByPk(userId);
-
-    if (!user) {
-      return res.status(404).json({ message: 'Authenticated user not found' });
+    //if the user is attempting to update themselves
+    if (targetUserId === req.user.id) {
+      return res.status(403).json({
+        message: "wrong api endpoint for updating your own user information",
+      })
     }
+    //if the user is attempting to update the role_id
+
+    if (updatedData.role_id !== undefined) {
+      //if the user is not a super admin, they cannot update the role_id
+      if (!userIsSuperAdmin) {
+        return res
+          .status(403)
+          .json({ message: "You do not have permission to update a user's role_id" });
+      }
+      //check if the role_id for the target user is valid
+      if (!validRoles.includes(updatedData.role_id)) {
+        return res
+          .status(400)
+          .json({ message: "Invalid role_id provided for user being updated" });
+      }
+    }
+
+ 
 
     // Fetch the target user
     const targetUser = await Users.findByPk(targetUserId);
 
     if (!targetUser) {
-      return res.status(404).json({ message: 'Target user not found' });
+      return res.status(404).json({ message: "Target user not found" });
+    }
+    const targetUserIsAdmin = targetUser.role_id === 2;
+    const targetUserIsSuperAdmin = targetUser.role_id === 3;
+
+    // aditional role based access control. these are after the fetch of the target user because we need to know certain details about the target user to determine access. could/should we have done this before the fetch by getting the info some other way? 
+
+    // if a user is admin, they cannot update a user outside of their organization
+    if (userIsAdmin && targetUser.organization_id !== req.user.organization_id) {
+      return res.status(403).json({
+        message:
+          "You do not have permission to update a user outside of your organization",
+      });
+    }
+    // if a user is admin, they cannot update any other admin or any super admin
+    if (userIsAdmin && (targetUserIsAdmin || targetUserIsSuperAdmin)) {
+      return res.status(403).json({
+        message: "You do not have permission to update another admin",
+      });
+    }
+
+    // Ensure only allowed fields are updated
+    const allowedUpdates = [
+      "first_name",
+      "last_name",
+      "email",
+      "password",
+      userIsSuperAdmin ? "role_id" : null,
+      "country_id",
+      "city_id",
+      "organization_id",
+    ];
+    const filteredUpdates = Object.keys(updatedData)
+      .filter((key) => allowedUpdates.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = updatedData[key];
+        return obj;
+      }, {});
+    //if no valid updates are provided
+    if (Object.keys(filteredUpdates).length === 0) {
+      return res.status(400).json({ message: "No valid updates provided" });
+    }
+    // Perform the update
+    await targetUser.update(filteredUpdates);
+
+    // Fetch the updated user with excluded sensitive fields
+    const updatedUser = await Users.findByPk(targetUserId, {
+      attributes: { exclude: ["password"] }, // Exclude sensitive fields
+    });
+
+    res.status(200).json({
+      message: "User updated successfully",
+      user: updatedUser,
+    });
+  } catch (err) {
+    console.log(err);
+    res.status(500).json({ message: err.message });
+  }
+});
+
+
+router.delete("/:id", auth, isAdmin, async (req, res) => {
+  const userRoleId = req.user.roleId; // Authenticated user's role ID
+  const userOrganizationId = req.user.organizationId; // Authenticated user's organization ID
+  const userIsAdmin = userRoleId === 2;
+  const { id: targetUserId } = req.params; // Target user ID to delete
+  
+  if(targetUserId === userId){
+    return res.status(403).json({
+      message: "You cannot delete your own user account",
+    });
+  }
+  try {
+    // Fetch the target user
+    const targetUser = await Users.findByPk(targetUserId);
+    const targetUserIsAdmin = targetUser.role_id === 2;
+    const targetUserIsSuperAdmin = targetUser.role_id === 3;
+
+    if (!targetUser) {
+      return res.status(404).json({ message: "Target user not found" });
     }
 
     // Role-based deletion rules
-    if (user.role_id !== 3) {
-      // Role 1: No permission to delete anyone
+    if(userIsAdmin){
+      // Admins can only delete users within the same organization
+      if(targetUser.organization_id !== userOrganizationId){
+        return res.status(403).json({
+          message: "You do not have permission to delete a user outside of your organization",
+        });
+      }
+    }
+    // admin cannot delete another admin or a super admin
+    if(userIsAdmin && (targetUserIsAdmin || targetUserIsSuperAdmin)){
       return res.status(403).json({
-        message: 'You do not have permission to delete users',
+        message: "You do not have permission to delete another admin",
       });
     }
+
+    // Super admins can delete any user
 
     // Proceed with deletion
     await targetUser.destroy();
@@ -260,10 +371,9 @@ router.delete('/:id', auth, async (req, res) => {
       message: `User with ID ${targetUserId} deleted successfully`,
     });
   } catch (err) {
+    console.log(err);
     res.status(500).json({ message: err.message });
   }
 });
 
-
 module.exports = router;
-

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -18,11 +18,9 @@ const auth = (req, res, next) => {
       return res.status(401).json({ message: 'No token provided' });
     }
 
-    console.log('Received Token:', token);
   
     try {
       const decoded = jwt.verify(token, secret);
-      console.log('Decoded Token:', decoded); 
   
       req.user = decoded;
   

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,5 +1,4 @@
 const jwt = require('jsonwebtoken');
-require('dotenv').config();
 
 const secret = process.env.SECRET;
 

--- a/middleware/isAdmin.js
+++ b/middleware/isAdmin.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
-require('dotenv').config();
-const { AdminPermissions, Users } = require('../models');
+
+const {  Users } = require('../models');
 
 const secret = process.env.SECRET;
 

--- a/middleware/isSuperAdmin.js
+++ b/middleware/isSuperAdmin.js
@@ -1,5 +1,4 @@
 const jwt = require('jsonwebtoken');
-require('dotenv').config();
 
 const secret = process.env.SECRET;
 

--- a/models/moduleModels/modules.js
+++ b/models/moduleModels/modules.js
@@ -59,9 +59,4 @@ Modules.init(
         underscored: true,
     }
 );
-
-Modules.belongsTo(Modules, { as: 'redirectedModule', foreignKey: 'redirect_module_id' });
-
-// Modules.belongsToMany(SubCategories, { as: 'subCategories', through: 'module_subcategory', foreignKey: 'module_id' });
-
 module.exports = Modules;

--- a/models/userModels/cities.js
+++ b/models/userModels/cities.js
@@ -31,6 +31,12 @@ Cities.init(
     timestamps: false,
     freezeTableName: true,
     underscored: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ["name", "country_id"], // alows duplicate city names, but only if they have unique country ids.  Name comparisons appear to be case-insensitive 
+      },
+    ],
   }
 );
 

--- a/models/userModels/countries.js
+++ b/models/userModels/countries.js
@@ -14,6 +14,7 @@ Countries.init(
     name: {
       type: DataTypes.STRING,
       allowNull: false,
+      unique: true
     },
   },
   {

--- a/models/userModels/organizations.js
+++ b/models/userModels/organizations.js
@@ -39,6 +39,12 @@ Organizations.init(
     timestamps: false,
     freezeTableName: true,
     underscored: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['name', 'country_id', 'city_id'], // Allows organizations to have duplicate names, but not if they have the same country_id and city_id as an existing entry
+      },
+    ],
   },
 );
 

--- a/models/userModels/users.js
+++ b/models/userModels/users.js
@@ -89,11 +89,6 @@ Users.init(
           user.password = await bcrypt.hash(user.password, saltRounds);
         }
       },
-      beforeUpdate: async (user) => {
-        if (user.changed('password')) {
-          user.password = await bcrypt.hash(user.password, saltRounds);
-        }
-      },
     },
   }
 );

--- a/models/userModels/users.js
+++ b/models/userModels/users.js
@@ -1,7 +1,10 @@
 const { Model, DataTypes } = require('sequelize');
 const sequelize = require('../../config/connection');
+const bcrypt = require('bcryptjs');
 
 class Users extends Model {}
+
+const saltRounds = 10;
 
 Users.init(
   {
@@ -79,6 +82,19 @@ Users.init(
     timestamps: true,
     freezeTableName: true,
     underscored: true, 
+    hooks: {
+      // Hash password before saving or updating
+      beforeSave: async (user) => {
+        if (user.changed('password')) {
+          user.password = await bcrypt.hash(user.password, saltRounds);
+        }
+      },
+      beforeUpdate: async (user) => {
+        if (user.changed('password')) {
+          user.password = await bcrypt.hash(user.password, saltRounds);
+        }
+      },
+    },
   }
 );
 

--- a/seeds/adminPermissions-seeds.js
+++ b/seeds/adminPermissions-seeds.js
@@ -8,6 +8,13 @@ const adminPermissions = [
     organization_id: 1,
     role_id: 1,
   },
+  {
+    admin_id: 8,
+    country_id: 2,
+    city_id: 3,
+    organization_id: 1,
+    role_id: 1,
+  },
 ];
 
 const adminPermissionsSeed = async () => {

--- a/seeds/users-seeds.js
+++ b/seeds/users-seeds.js
@@ -102,20 +102,50 @@ const users = [
     city_id: 1,
     organization_id: 1,
   },
+  {
+    first_name: "Michael",
+    last_name: "Seaman",
+    email: "mike1@mike.com",
+    password: "password",
+    role_id: 3,
+    country_id: 2,
+    city_id: 1,
+    organization_id: 1,
+  },
+  {
+    first_name: "Jenna",
+    last_name: "Seaman",
+    email: "jenna@jenna.com",
+    password: "password",
+    role_id: 1,
+    country_id: null,
+    city_id: null,
+    organization_id: 1,
+  },
+  {
+    first_name: "Dave",
+    last_name: "West",
+    email: "dave@dave.com",
+    password: "password",
+    role_id: 2,
+    country_id: 1,
+    city_id: 1,
+    organization_id: 1,
+  },
 ];
 
 const usersSeed = async () => {
   try {
     // Hash passwords for all users
-    const hashedUsers = await Promise.all(
-      users.map(async (user) => {
-        const hashedPassword = await bcrypt.hash(user.password, 10); // Salt rounds set to 10
-        return { ...user, password: hashedPassword };
-      })
-    );
+    // const hashedUsers = await Promise.all(
+    //   users.map(async (user) => {
+    //     const hashedPassword = await bcrypt.hash(user.password, 10); // Salt rounds set to 10
+    //     return { ...user, password: hashedPassword };
+    //   })
+    // );
 
     // Seed users with hashed passwords
-    await Users.bulkCreate(hashedUsers);
+    await Users.bulkCreate(users, { individualHooks: true });
     console.log('Users seeded successfully!');
   } catch (err) {
     console.error('Error seeding users:', err);

--- a/seeds/users-seeds.js
+++ b/seeds/users-seeds.js
@@ -136,15 +136,7 @@ const users = [
 
 const usersSeed = async () => {
   try {
-    // Hash passwords for all users
-    // const hashedUsers = await Promise.all(
-    //   users.map(async (user) => {
-    //     const hashedPassword = await bcrypt.hash(user.password, 10); // Salt rounds set to 10
-    //     return { ...user, password: hashedPassword };
-    //   })
-    // );
 
-    // Seed users with hashed passwords
     await Users.bulkCreate(users, { individualHooks: true });
     console.log('Users seeded successfully!');
   } catch (err) {

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ const app = express();
 const sequelize = require('./config/connection');
 const port = process.env.PORT || 3000;
 const auth = require('./middleware/auth');
-require('dotenv').config();
 
 const routes = require('./controllers/api/index');
 
@@ -14,12 +13,6 @@ app.use(routes);
 
 app.use('/auth', auth);
 
-
-//the following two lines of code could allow us to use force: true in development and not in production, but I would want this code to be thoroughly reviewed before implementing
-
-// const isProduction = process.env.NODE_ENV === 'production';
-
-// sequelize.sync({ force: !isProduction })
 sequelize.sync({ force: false })
   .then(async() => {
     console.log('Database synced');

--- a/server.js
+++ b/server.js
@@ -14,6 +14,12 @@ app.use(routes);
 
 app.use('/auth', auth);
 
+
+//the following two lines of code could allow us to use force: true in development and not in production, but I would want this code to be thoroughly reviewed before implementing
+
+// const isProduction = process.env.NODE_ENV === 'production';
+
+// sequelize.sync({ force: !isProduction })
 sequelize.sync({ force: false })
   .then(async() => {
     console.log('Database synced');


### PR DESCRIPTION
The main thing to consider about these user routes is weather or not they should be redone to utilize the AdminPermissions table. I structured these routes to create permissions and restrictions based off of the user's organization_id, operating under the assumption that users will be associated with just one organization. Super-admins don't have any restrictions. However, if need be, these routes could be restructured to utilize the AdminPermissions table for more flexibility
The hashing of passwords now only occurs in a 'beforeSave' hook, which handles the hashing during create, bulkCreate, and update queries
The Cities and Organization models now have an 'indexes' property which allows for duplicate names, but only if certain other properties are unique (i .e two cities can have the same name as long as they are in different countries)
In server.js I have some commented-out code that, if implemented, should set force: true in the sequelize.sync() call when in development, and set force: false in production. However, I left it commented out because I wouldn't want to do anything destructive to the production database if somehow that code didn't work as intended. Thus, for now, force has been set to false and I manually change it to 'true' if I need to apply changes to the db structure and then i set it back to false afterwards