### PR TITLE
update get quiz-score route to check for admin status manually

### DIFF
--- a/controllers/api/moduleRoutes/quizScoreRoutes.js
+++ b/controllers/api/moduleRoutes/quizScoreRoutes.js
@@ -2,14 +2,16 @@ const router = require('express').Router();
 const { QuizScores, Modules } = require('../../../models');
 const auth = require('../../../middleware/auth');
 const isAdmin = require('../../../middleware/isAdmin');
+const ROLES = require('../../../utils/roles');
 
 router.get('/', auth, async (req, res) => {
   const { userId } = req.query;
+  const userIsAdmin = req.user && (req.user.roleId === ROLES.ADMIN || req.user.roleId === ROLES.SUPER_ADMIN);
 
   try {
     let quizScores;
 
-    if (req.user.isAdmin) {
+    if (userIsAdmin) {
     
       const parsedUserId = userId ? parseInt(userId, 10) : null;
       const whereClause = parsedUserId ? { user_id: parsedUserId } : {};

--- a/controllers/api/moduleRoutes/quizScoreRoutes.js
+++ b/controllers/api/moduleRoutes/quizScoreRoutes.js
@@ -45,6 +45,7 @@ router.get('/', auth, async (req, res) => {
 
 router.get('/:id', auth, async (req, res) => {
   const { id } = req.params;
+  const userIsAdmin = req.user && (req.user.roleId === ROLES.ADMIN || req.user.roleId === ROLES.SUPER_ADMIN);
   try {
     const quizScore = await QuizScores.findByPk(id, {
       attributes: ['id', 'user_id', 'module_id', 'score', 'date_taken'],
@@ -55,7 +56,7 @@ router.get('/:id', auth, async (req, res) => {
     }
 
     // Ensure users can access only their own scores
-    if (!req.user.isAdmin && quizScore.user_id !== req.user.id) {
+    if (!userIsAdmin && quizScore.user_id !== req.user.id) {
       return res.status(403).json({ message: 'Access denied' });
     }
 


### PR DESCRIPTION
I believe the previous code was misusing ".isAdmin" as a property of req.user.  I updated the query for quiz-scores to conditionally check the role of the requesting user using .roleId instead